### PR TITLE
文本检测翻译功能调整，新增导入压缩图片功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ files:
 ![text_quickfix.gif](doc/text_quickfix.gif)
 - 自定义规则检测不合规控件使用并一键修复 
 ![widget_quickfix.gif](doc/widget_quickfix.gif)
+- 图片文件快捷导入并压缩
+![widget_import_image.gif](doc/widget_import_image.gif)
 - 一键同步crowdin的翻译文本到本地项目
 ![download_intl.gif](doc/download_intl.gif)
 - 一键上传待翻译文本到crowdin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hammer",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hammer",
-            "version": "1.6.2",
+            "version": "1.7.0",
             "license": "MIT",
             "dependencies": {
                 "@crowdin/crowdin-api-client": "1.11.7",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Hammer",
     "description": "Hammer for Visual Studio Code",
     "publisher": "zhileichen",
-    "version": "1.6.6",
+    "version": "1.7.0",
     "license": "MIT",
     "engines": {
         "vscode": "^1.35.0"
@@ -38,6 +38,24 @@
                         "type": "boolean",
                         "default": "false",
                         "description": "Enables or disables auto refresh after each change in Crowdin configuration file.",
+                        "scope": "window"
+                    },
+                    "tms.onlyCheckChineseCharacters": {
+                        "type": "boolean",
+                        "default": "true",
+                        "description": "Only check chinese characters untranslated.",
+                        "scope": "window"
+                    },
+                    "tms.formatLanguageJson": {
+                        "type": "boolean",
+                        "default": "false",
+                        "description": "Format the language json file when add translations。",
+                        "scope": "window"
+                    },
+                    "tms.imageCompressScript": {
+                        "type": "string",
+                        "default": "squoosh-cli --webp \"{\"effort\":6}\" $inFilePath$ -d $outinFilePath$",
+                        "description": "The shell command to compress image before move it into project.",
                         "scope": "window"
                     }
                 }
@@ -111,6 +129,10 @@
             {
                 "command": "hammer.wrapObserver",
                 "title": "Wrap with Observer"
+            },
+            {
+                "command": "images.import",
+                "title": "[Hammer] Import image from file"
             }
         ],
         "menus": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,9 @@ export class Constants {
     static EXTENSION_CONTEXT: vscode.ExtensionContext;
     static readonly OPEN_TMS_FILE_COMMAND = 'extension.openTmsFile';
     static readonly AUTO_REFRESH_PROPERTY = 'tms.autoRefresh';
+    static readonly ONLY_CHECK_CHINESE = 'tms.onlyCheckChineseCharacters';
+    static readonly FORMAT_LANGUAGE_JSON = 'tms.formatLanguageJson';
+    static readonly COMPRESS_IMAGE_SCRIPT = 'tms.imageCompressScript';
     static readonly CROWDIN_PATH_SEPARATOR = '/';
     static readonly PLUGIN_VERSION = '1.0.3';
     static readonly CLIENT_RETRIES = 5;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { genProtoCommand } from './plugin/generator/protoGenerator';
 import { genMobxCommand } from './plugin/generator/mobxstoreGenerator';
 import { enableNullSafety } from './plugin/nullsafety/enable_nullsafety';
 import { WrapObserverCodeActionProvider, wrapObserverCommand } from './plugin/diagnostics/wrapWithObserver';
+import { importImage } from './plugin/importImages/importImageAction';
 
 export async function activate(context: vscode.ExtensionContext) {
     Constants.initialize(context);
@@ -47,6 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('hammer.enable_null_safety', args => enableNullSafety(args));
     vscode.commands.registerCommand('hammer.wrapObserver', args => wrapObserverCommand(args));
 
+    vscode.commands.registerCommand('images.import', args => importImage(args));
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
         if (e.affectsConfiguration(Constants.AUTO_REFRESH_PROPERTY)) {

--- a/src/plugin/importImages/importImageAction.ts
+++ b/src/plugin/importImages/importImageAction.ts
@@ -1,0 +1,112 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as cp from "child_process";
+import { PathUtil } from '../../util/pathUtil';
+import { Constants } from '../../constants';
+import { Document } from 'yaml';
+import { CommonUtil } from '../../util/commonUtil';
+
+const imagesRelativePath = 'assets/images/';
+
+
+class ImportImageAction {
+    constructor(
+        private workspaceRoot: string,
+        private args: any,
+    ) { }
+    async run() {
+        let editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return; // No open text editor
+        }
+
+        if (path.extname(editor.document.uri.path) !== '.dart') {
+            vscode.window.showInformationMessage('active document is not dart file');
+            return;
+        }
+
+        let imageName: string | undefined;
+        let packageName: string | undefined;
+
+        const selection = editor.selection;
+        const selectedText = editor.document.getText(new vscode.Range(selection.anchor, selection.active));
+        if (selectedText.length == 0) {
+            imageName = await vscode.window.showInputBox({ placeHolder: `Enter the image name` }) ?? '';
+            packageName = CommonUtil.getCurrentPackageName();
+        } else {
+            // get image name
+            let regex = /(?<=['"])(.+)(?=['"])/g;
+            const imageNameReg = regex.exec(selectedText);
+            if (imageNameReg && imageNameReg.length > 0) {
+                imageName = imageNameReg[0].replace(/[\r\n\s\ ]/g, "");
+            }
+
+            // get package name
+            regex = /(?<=ComponentManager.)(.+)(\s*)(?=\))/g;
+            const packageNameReg = regex.exec(selectedText);
+            if (packageNameReg && packageNameReg.length > 0) {
+                packageName = packageNameReg[0].replace(/[\r\n\s\ ]/g, '').replace('MANAGER_', '').toLowerCase();
+            }
+        }
+
+        if (!imageName || imageName.length == 0) {
+            vscode.window.showInformationMessage('image name is undefined');
+            return;
+        }
+        if (!packageName || packageName.length == 0) {
+            vscode.window.showInformationMessage('package name is undefined');
+            return;
+        }
+
+        // select image file
+        const dialogOptions: vscode.OpenDialogOptions = { defaultUri: vscode.Uri.parse('~/Downloads/') };
+        dialogOptions.filters = { 'Images': ['png', 'webp', 'jpg', 'jpeg', 'svg'] };
+        const dialogRes = await vscode.window.showOpenDialog(dialogOptions);
+        if (dialogRes == undefined || dialogRes.length == 0) {
+            return;
+        }
+        let filePath = (dialogRes as vscode.Uri[])[0].path;
+
+        // asset/images dir
+        const imagesDirPath = packageName == undefined ? `${this.workspaceRoot}/assets/images` : `${this.workspaceRoot}/banban_base/${packageName}/assets/images`;
+
+        // select sub image dir
+        const subImgDirs: string[] = ['.'];
+        const subImgDirNameFunc = fs.readdirSync(imagesDirPath);
+        subImgDirNameFunc.forEach(function (subDirName) {
+            const subDir = path.join(imagesDirPath, subDirName);
+            if (fs.statSync(subDir).isDirectory()) {
+                subImgDirs.push(packageName == undefined ? subDirName : `${packageName}/${subDirName}`);
+            }
+        });
+        let subImgDir: string | undefined;
+        if (subImgDirs.length > 1) {
+            subImgDir = await vscode.window.showQuickPick(subImgDirs);
+        }
+
+        // destination dir
+        const destinationPath = ((subImgDir != undefined && subImgDir != '.') ? path.join(imagesDirPath, subImgDir) : imagesDirPath) + '/' + imageName;
+
+        // pre script
+        let compressScript = vscode.workspace.getConfiguration().get<string>(Constants.COMPRESS_IMAGE_SCRIPT);
+        if (compressScript != null && compressScript.length > 0) {
+            const scriptOutDir = path.dirname(filePath);
+            compressScript = compressScript.replace('$inFilePath$', filePath);
+            compressScript = compressScript.replace('$outinFilePath$', scriptOutDir);
+            const shellScript = await vscode.window.showQuickPick([compressScript, 'skip']);
+            if (shellScript != 'skip') {
+                const result = cp.execSync(compressScript).toString("utf8").trim();
+                filePath = filePath.replace(path.extname(filePath), '.webp');
+            }
+        }
+
+        // rename and copy image file
+        fs.writeFileSync(destinationPath, fs.readFileSync(filePath));
+    }
+}
+
+
+export async function importImage(args: any) {
+    await new ImportImageAction(vscode.workspace.rootPath ?? '', args).run();
+}

--- a/src/util/commonUtil.ts
+++ b/src/util/commonUtil.ts
@@ -1,4 +1,7 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+import { PathUtil } from './pathUtil';
+
 export type NullAsUndefined<T> = null extends T ? Exclude<T, null> | undefined : T;
 
 export class CommonUtil {
@@ -44,5 +47,31 @@ export class CommonUtil {
 
     static nullToUndefined<T>(value: T): NullAsUndefined<T> {
         return (value === null ? undefined : value) as NullAsUndefined<T>;
+    }
+
+    static getPackagePath(dir: string | undefined): string | undefined {
+        if (dir == undefined) {
+            var editor = vscode.window.activeTextEditor;
+            dir = editor?.document.uri.path;
+        }
+
+        if (dir == vscode.workspace.rootPath ?? '') return undefined;
+
+        var parentDir = path.dirname(dir as string);
+
+        var yamlFilePath = path.join(parentDir, 'pubspec.yaml');
+        if (PathUtil.pathExists(yamlFilePath)) {
+            return parentDir;
+        }
+
+        return this.getPackagePath(parentDir);
+    }
+
+    static getCurrentPackageName(): string | undefined {
+        const packagePath = this.getPackagePath(undefined);
+        if (packagePath == undefined) {
+            return undefined;
+        }
+        return path.basename(packagePath);
     }
 }


### PR DESCRIPTION
1. 未翻译文本检测增加设置 —— 只针对包含中文的定义显示警告（开关默认开启）；
2. 未翻译文本修复功能增加格式化开关，关闭格式化开关会基于现有文件格式进行增量插入，兼容BanBanTranslate插件的格式，避免引入一些不必要的change，同时方便查看翻译文件的diff（开关默认关闭）；
3. 翻译文本修复后自动保存修改的文件；
4. 增加图片资源导入功能，写好图片widget后选择图片，直接完成压缩（压缩命令可在设置中自定义）、重名命、导入等工作，提高开发效率（也可直接键入命令导入图片）；